### PR TITLE
Use keepalive and reduce ping interval

### DIFF
--- a/core/src/main/java/com/threerings/presents/client/BlockingCommunicator.java
+++ b/core/src/main/java/com/threerings/presents/client/BlockingCommunicator.java
@@ -660,6 +660,7 @@ public class BlockingCommunicator extends Communicator
             InetAddress host = InetAddress.getByName(_client.getHostname());
             openChannel(host);
             _channel.configureBlocking(true);
+            _channel.socket().setKeepAlive(true);
 
             // our messages are framed (preceded by their length), so we use these helper streams
             // to manage the framing

--- a/core/src/main/java/com/threerings/presents/net/PingRequest.java
+++ b/core/src/main/java/com/threerings/presents/net/PingRequest.java
@@ -17,7 +17,7 @@ public class PingRequest extends UpstreamMessage
 {
     /** The number of milliseconds of idle upstream that are allowed to elapse before the client
      * sends a ping message to the server to let it know that we're still alive. */
-    public static final long PING_INTERVAL = 60 * 1000L;
+    public static final long PING_INTERVAL = 30 * 1000L;
 
     /**
      * Zero argument constructor used when unserializing an instance.


### PR DESCRIPTION
Some networks will kill connections sooner than 60s, especially if they are not using keepalive. This fix should reduce the random disconnects some players experience